### PR TITLE
turbo handbook drive: updated translation

### DIFF
--- a/tasks/diff_task.rb
+++ b/tasks/diff_task.rb
@@ -25,7 +25,7 @@ class DiffTask
           next unless translated_file
 
           source_latest_commit, diff_content = diff(source_file, translated_file)
-          next unless diff_content
+          next if diff_content.nil? || diff_content.empty?
 
           translation_pr = TranslationPr.new(translation_repository_path,
                                              translated_file,

--- a/tasks/translated_file.rb
+++ b/tasks/translated_file.rb
@@ -19,6 +19,7 @@ class TranslatedFile
   end
 
   def update_commit_hash(new_commit)
+    return if new_commit == front_matter[:commit]
     updated_content = content.sub(/(commit:\s*")[^"]+(")/, "\\1#{new_commit}\\2")
     path.write(updated_content)
   end

--- a/tasks/translation_pr.rb
+++ b/tasks/translation_pr.rb
@@ -147,7 +147,7 @@ DESCRIPTION
        "create",
        "--title", title,
        "--body", description,
-       "--base", "auto-translations-update",
+       "--base", "main",
        "--head", branch,
        "--repo", repo)
   end

--- a/tasks/translation_pr.rb
+++ b/tasks/translation_pr.rb
@@ -91,15 +91,20 @@ DESCRIPTION
 
   def find_existed_pr
     pr_raw_info = Tempfile.open("pr.json") do |pr|
-      sh("gh",
-         "pr",
-         "view",
-         branch,
-         "--json", "closed,title,body",
-         "--repo", repo,
-         {out: pr}
-      )
-      pr.open.read
+      begin
+        sh("gh",
+          "pr",
+          "view",
+          branch,
+          "--json", "closed,title,body",
+          "--repo", repo,
+          {out: pr}
+        )
+        pr.open.read
+      rescue RuntimeError
+        # When existed pr doesn't exist, gh command raises RuntimeError.
+        ""
+      end
     end
     if pr_raw_info.empty?
       [nil, nil]

--- a/tasks/translation_pr.rb
+++ b/tasks/translation_pr.rb
@@ -118,7 +118,8 @@ DESCRIPTION
   end
 
   def commit_latest_hash(source_latest_commit)
-    translated_file.update_commit_hash(source_latest_commit)
+    return unless translated_file.update_commit_hash(source_latest_commit)
+
     sh("git", "add", translated_file.path.to_s)
     sh("git",
        "commit",

--- a/tasks/translation_pr.rb
+++ b/tasks/translation_pr.rb
@@ -35,7 +35,7 @@ class TranslationPr
   DIFF_END = "<!-- Please write your description under here. -->"
 
   def repo
-    "#{onwer}/#{repository}"
+    "#{owner}/#{repository}"
   end
 
   def owner

--- a/turbo/handbook/drive.md
+++ b/turbo/handbook/drive.md
@@ -2,7 +2,7 @@
 title: "Turbo ドライブを使ったナビゲート"
 description: "Turbo ドライブは、ページ全体の再読み込みの必要を無くすことで、リンクとフォームの送信を高速化します。"
 order: 2
-commit: "3b06afb"
+commit: "8849e6b"
 ---
 
 # Turbo ドライブを使ったナビゲート


### PR DESCRIPTION
## Diff (Please don't change this section. It will be automatically updated.)

~~~diff
diff --git a/_source/handbook/02_drive.md b/_source/handbook/02_drive.md
index 3b3675a..29cdc15 100644
--- a/_source/handbook/02_drive.md
+++ b/_source/handbook/02_drive.md
@@ -15,6 +15,8 @@ Turbo Drive models page navigation as a *visit* to a *location* (URL) with an *a
 
 Visits represent the entire navigation lifecycle from click to render. That includes changing browser history, issuing the network request, restoring a copy of the page from cache, rendering the final response, and updating the scroll position.
 
+During rendering, Turbo Drive replaces the contents of the requesting document's `<body>` with the contents of the response document's `<body>`, merges the contents of their `<head>`s too, and updates the `lang` attribute of the `<html>` element as needed. The point of merging instead of replacing the `<head>` elements is that if `<title>` or `<meta>` tags change, say, they will be updated as expected, but if links to assets are the same, they won't be touched and therefore the browser won't process them again.
+
 There are two types of visit: an _application visit_, which has an action of _advance_ or _replace_, and a _restoration visit_, which has an action of _restore_.
 
 ## Application Visits
@@ -73,15 +75,31 @@ Listen for the `turbo:before-visit` event to be notified when a visit is about t
 
 Restoration visits cannot be canceled and do not fire `turbo:before-visit`. Turbo Drive issues restoration visits in response to history navigation that has *already taken place*, typically via the browser’s Back or Forward buttons.
 
+## Custom Rendering
+
+Applications can customize the rendering process by adding a document-wide `turbo:before-render` event listener and overriding the `event.detail.render` property.
+
+For example, you could merge the response document's `<body>` element into the requesting document's `<body>` element with [idiomorph](https://github.com/bigskysoftware/idiomorph) or [morphdom](https://github.com/patrick-steele-idem/morphdom):
+
+```javascript
+import { Idiomorph } from "idiomorph"
+
+addEventListener("turbo:before-render", (event) => {
+  event.detail.render = (currentElement, newElement) => {
+    Idiomorph.morph(currentElement, newElement)
+  }
+})
+```
+
 ## Pausing Rendering
 
-Application can pause rendering and make additional preparation before it will be executed.
+Applications can pause rendering and make additional preparations before continuing.
 
 Listen for the `turbo:before-render` event to be notified when rendering is about to start, and pause it using `event.preventDefault()`. Once the preparation is done continue rendering by calling `event.detail.resume()`.
 
 An example use case is adding exit animation for visits:
 ```javascript
-document.addEventListener('turbo:before-render', async (event) => {
+document.addEventListener("turbo:before-render", async (event) => {
   event.preventDefault()
 
   await animateOut()
@@ -98,11 +116,11 @@ Listen for the `turbo:before-fetch-request` event to be notified when a request
 
 An example use case is setting `Authorization` header for the request:
 ```javascript
-document.addEventListener('turbo:before-fetch-request', async (event) => {
+document.addEventListener("turbo:before-fetch-request", async (event) => {
   event.preventDefault()
 
   const token = await getSessionToken(window.app)
-  event.detail.fetchOptions.headers['Authorization'] = `Bearer ${token}`
+  event.detail.fetchOptions.headers["Authorization"] = `Bearer ${token}`
 
   event.detail.resume()
 })
@@ -120,6 +138,17 @@ The link will get converted into a hidden form next to the `a` element in the DO
 
 You should also consider that for accessibility reasons, it's better to use actual forms and buttons for anything that's not a GET.
 
+## Requiring Confirmation for a Visit
+
+Decorate links with both `data-turbo-confirm` and `data-turbo-method`, and confirmation will be required for a visit to proceed.
+
+```html
+<a href="/articles" data-turbo-method="get" data-turbo-confirm="Do you want to leave this page?">Back to articles</a>
+<a href="/articles/54" data-turbo-method="delete" data-turbo-confirm="Are you sure you want to delete the article?">Delete the article</a>
+```
+
+Use `Turbo.setConfirmMethod` to change the method that gets called for confirmation. The default is the browser's built in `confirm`.
+
 
 ## Disabling Turbo Drive on Specific Links or Forms
 
@@ -129,13 +158,13 @@ Turbo Drive can be disabled on a per-element basis by annotating the element or
 <a href="/" data-turbo="false">Disabled</a>
 
 <form action="/messages" method="post" data-turbo="false">
-  ...
+  <!-- … -->
 </form>
 
 <div data-turbo="false">
   <a href="/">Disabled</a>
   <form action="/messages" method="post">
-    ...
+    <!-- … -->
   </form>
 </div>
 ```
@@ -157,6 +186,30 @@ import { Turbo } from "@hotwired/turbo-rails"
 Turbo.session.drive = false
 ```
 
+## View transitions
+
+In [browsers that support](https://caniuse.com/?search=View%20Transition%20API) the [View Transition API](https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API) Turbo can trigger view transitions when navigating between pages.
+
+Turbo triggers a view transition when both the current and the next page have this meta tag:
+
+```
+<meta name="view-transition" content="same-origin" />
+```
+
+Turbo also adds a `data-turbo-visit-direction` attribute to the `<html>` element to indicate the direction of the transition. The attribute can have one of the following values:
+
+- `forward` in advance visits.
+- `back` in restoration visits.
+- `none` in replace visits.
+
+You can use this attribute to customize the animations that are performed during a transition:
+
+```css
+html[data-turbo-visit-direction="forward"]::view-transition-old(sidebar):only-child {
+  animation: slide-to-right 0.5s ease-out;
+}
+```
+
 ## Displaying Progress
 
 During Turbo Drive navigation, the browser will not display its native progress indicator. Turbo Drive installs a CSS-based progress bar to provide feedback while issuing a request.
@@ -188,25 +241,43 @@ In tandem with the progress bar, Turbo Drive will also toggle the [`[aria-busy]`
 
 ## Reloading When Assets Change
 
-Turbo Drive can track the URLs of asset elements in `<head>` from one page to the next and automatically issue a full reload if they change. This ensures that users always have the latest versions of your application’s scripts and styles.
+As we saw above, Turbo Drive merges the contents of the `<head>` elements. However, if CSS or JavaScript change, that merge would evaluate them on top of the existing one. Typically, this would lead to undesirable conflicts. In such cases, it's necessary to fetch a completely new document through a standard, non-Ajax request.
 
-Annotate asset elements with `data-turbo-track="reload"` and include a version identifier in your asset URLs. The identifier could be a number, a last-modified timestamp, or better, a digest of the asset’s contents, as in the following example.
+To accomplish this, just annotate those asset elements with `data-turbo-track="reload"` and include a version identifier in your asset URLs. The identifier could be a number, a last-modified timestamp, or better, a digest of the asset’s contents, as in the following example.
 
 ```html
 <head>
-  ...
+  <!-- … -->
   <link rel="stylesheet" href="/application-258e88d.css" data-turbo-track="reload">
   <script src="/application-cbd3cd4.js" data-turbo-track="reload"></script>
 </head>
 ```
 
+## Removing Assets When They Change
+
+As we saw above, Turbo Drive merges the contents of the `<head>` elements. When a page depends on external assets like CSS stylesheets that other pages do not, it can be useful to remove them when navigating away from the page.
+
+Rendering a `<link>` or `<style>` element with `[data-turbo-track="dynamic"]` instructs Turbo Drive to dynamically remove the element when it is absent from a navigation's response, and can serve a complementary role to the [`[data-turbo-track="reload"]`](#reload-when-assets-change) attribute to avoid triggering a full page reload when deploying changes that only affect styles.
+
+```html
+<head>
+  <!-- … -->
+  <link rel="stylesheet" href="/page-specific-styles-258e88d.css" data-turbo-track="dynamic">
+  <style data-turbo-track="dynamic">
+    .page-specific-styles { /* … */ }
+  </style>
+</head>
+```
+
+Note that rendering `<script>` elements with `[data-turbo-track="dynamic"]` might unintended side-effects. When `<script>` disconnected from the document, the JavaScript context doesn't change, nor is the element's already evaluated JavaScript code unloaded or changed in any way.
+
 ## Ensuring Specific Pages Trigger a Full Reload
 
 You can ensure visits to a certain page will always trigger a full reload by including a `<meta name="turbo-visit-control">` element in the page’s `<head>`.
 
 ```html
 <head>
-  ...
+  <!-- … -->
   <meta name="turbo-visit-control" content="reload">
 </head>
 ```
@@ -215,7 +286,7 @@ This setting may be useful as a workaround for third-party JavaScript libraries
 
 ## Setting a Root Location
 
-By default, Turbo Drive only loads URLs with the same origin—i.e. the same protocol, domain name, and port—as the current document. A visit to any other URL falls back to a full page load.
+Turbo Drive only loads URLs with the same origin—i.e. the same protocol, domain name, and port—as the current document. A visit to any other URL falls back to a full page load.
 
 In some cases, you may want to further scope Turbo Drive to a path on the same origin. For example, if your Turbo Drive application lives at `/app`, and the non-Turbo Drive help site lives at `/help`, links from the app to the help site shouldn’t use Turbo Drive.
 
@@ -223,7 +294,7 @@ Include a `<meta name="turbo-root">` element in your pages’ `<head>` to scope
 
 ```html
 <head>
-  ...
+  <!-- … -->
   <meta name="turbo-root" content="/app">
 </head>
 ```
@@ -240,7 +311,7 @@ target the `<form>` element and [bubble up][] through the document:
 3. `turbo:before-fetch-response`
 4. `turbo:submit-end`
 
-During a submission, Turbo Drive will set the "submitter" element's [disabled][] attribute when the submission begins, then remove the attribute after the submission ends. When submitting a `<form>` element, browser's will treat the `<input type="submit">` or `<button>` element that initiated the submission as the [submitter][]. To submit a `<form>` element programmatically, invoke the [HTMLFormElement.requestSubmit()][] method and pass an `<input type="submit">` or `<button>` element as an optional parameter.
+During a submission, Turbo Drive will set the "submitter" element's [disabled][] attribute when the submission begins, then remove the attribute after the submission ends. When submitting a `<form>` element, browsers will treat the `<input type="submit">` or `<button>` element that initiated the submission as the [submitter][]. To submit a `<form>` element programmatically, invoke the [HTMLFormElement.requestSubmit()][] method and pass an `<input type="submit">` or `<button>` element as an optional parameter.
 
 If there are other changes you'd like to make during a `<form>` submission (for
 example, disabling _all_ [fields within a submitted `<form>`][elements]), you
@@ -255,7 +326,7 @@ addEventListener("turbo:submit-start", ({ target }) => {
 ```
 
 [events]: /reference/events
-[bubble up]: https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_bubbling_and_capture
+[bubble up]: https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_bubbling
 [elements]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/elements
 [disabled]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled
 [submitter]: https://developer.mozilla.org/en-US/docs/Web/API/SubmitEvent/submitter
@@ -265,7 +336,7 @@ addEventListener("turbo:submit-start", ({ target }) => {
 
 After a stateful request from a form submission, Turbo Drive expects the server to return an [HTTP 303 redirect response](https://en.wikipedia.org/wiki/HTTP_303), which it will then follow and use to navigate and update the page without reloading.
 
-The exception to this rule is when the response is rendered with either a 4xx or 5xx status code. This allows form validation errors to be rendered by having the server respond with `422 Unprocessable Entity` and a broken server to display a "Something Went Wrong" screen on a `500 Internal Server Error`.
+The exception to this rule is when the response is rendered with either a 4xx or 5xx status code. This allows form validation errors to be rendered by having the server respond with `422 Unprocessable Content` and a broken server to display a "Something Went Wrong" screen on a `500 Internal Server Error`.
 
 The reason Turbo doesn't allow regular rendering on 200's from POST requests is that browsers have built-in behavior for dealing with reloads on POST visits where they present a "Are you sure you want to submit this form again?" dialogue that Turbo can't replicate. Instead, Turbo will stay on the current URL upon a form submission that tries to render, rather than change it to the form action, since a reload would then issue a GET against that action URL, which may not even exist.
 
@@ -274,4 +345,86 @@ If the form submission is a GET request, you may render the directly rendered re
 ## Streaming After a Form Submission
 
 Servers may also respond to form submissions with a [Turbo Streams](streams) message by sending the header `Content-Type: text/vnd.turbo-stream.html` followed by one or more `<turbo-stream>` elements in the response body. This lets you update multiple parts of the page without navigating.
+
+## Prefetching Links on Hover
+
+Turbo can also speed up perceived link navigation latency by automatically loading links on `mouseenter` events, and before the user clicks the link. This usually leads to a speed bump of 500-800ms per click navigation.
+
+Prefetching links is enabled by default since Turbo v8, but you can disable it by adding this meta tag to your page:
+
+```html
+<meta name="turbo-prefetch" content="false">
+```
+
+To avoid prefetching links that the user is briefly hovering, Turbo waits 100ms after the user hovers over the link before prefetching it. But you may want to disable the prefetching behavior on certain links leading to pages with expensive rendering.
+
+You can disable the behavior on a per-element basis by annotating the element or any of its ancestors with `data-turbo-prefetch="false"`.
+
+```html
+<html>
+  <head>
+    <meta name="turbo-prefetch" content="true">
+  </head>
+  <body>
+    <a href="/articles">Articles</a> <!-- This link is prefetched -->
+    <a href="/about" data-turbo-prefetch="false">About</a> <!-- Not prefetched -->
+    <div data-turbo-prefetch="false">
+      <!-- Links inside this div will not be prefetched -->
+    </div>
+  </body>
+</html>
+```
+
+You can also disable the behaviour programatically by intercepting the `turbo:before-prefetch` event and calling `event.preventDefault()`.
+
+```javascript
+document.addEventListener("turbo:before-prefetch", (event) => {
+  if (isSavingData() || hasSlowInternet()) {
+    event.preventDefault()
+  }
+})
+
+function isSavingData() {
+  return navigator.connection?.saveData
+}
+
+function hasSlowInternet() {
+  return navigator.connection?.effectiveType === "slow-2g" ||
+         navigator.connection?.effectiveType === "2g"
+}
+```
+
+## Preload Links Into the Cache
+
+Preload links into Turbo Drive's cache using the [data-turbo-preload][] boolean attribute.
+
+This will make page transitions feel lightning fast by providing a preview of a page even before the first visit. Use it to preload the most important pages in your application. Avoid over usage, as it will lead to loading content that is not needed.
+
+Not every `<a>` element can be preloaded. The `[data-turbo-preload]` attribute
+won't have any effect on links that:
+
+* navigate to another domain
+* have a `[data-turbo-frame]` attribute that drives a `<turbo-frame>` element
+* drive an ancestor `<turbo-frame>` element
+* have the `[data-turbo="false"]` attribute
+* have the `[data-turbo-stream]` attribute
+* have a `[data-turbo-method]` attribute
+* have an ancestor with the `[data-turbo="false"]` attribute
+* have an ancestor with the `[data-turbo-prefetch="false"]` attribute
+
+It also dovetails nicely with pages that leverage [Eager-Loading Frames](/reference/frames#eager-loaded-frame) or [Lazy-Loading Frames](/reference/frames#lazy-loaded-frame). As you can preload the structure of the page and show the user a meaningful loading state while the interesting content loads.
 <br><br>
+
+Note that preloaded `<a>` elements will dispatch [turbo:before-fetch-request](/reference/events) and [turbo:before-fetch-response](/reference/events) events. To distinguish a preloading `turbo:before-fetch-request` initiated event from an event initiated by another mechanism, check whether the request's `X-Sec-Purpose` header (read from the `event.detail.fetchOptions.headers["X-Sec-Purpose"]` property) is set to `"prefetch"`:
+
+```js
+addEventListener("turbo:before-fetch-request", (event) => {
+  if (event.detail.fetchOptions.headers["X-Sec-Purpose"] === "prefetch") {
+    // do additional preloading setup…
+  } else {
+    // do something else…
+  }
+})
+```
+
+[data-turbo-preload]: /reference/attributes#data-attributes

~~~

<!-- Please write your description under here. -->

