### PR TITLE
turbo handbook frames: updated translation

### DIFF
--- a/tasks/diff_task.rb
+++ b/tasks/diff_task.rb
@@ -25,7 +25,7 @@ class DiffTask
           next unless translated_file
 
           source_latest_commit, diff_content = diff(source_file, translated_file)
-          next unless diff_content
+          next if diff_content.nil? || diff_content.empty?
 
           translation_pr = TranslationPr.new(translation_repository_path,
                                              translated_file,

--- a/tasks/translated_file.rb
+++ b/tasks/translated_file.rb
@@ -19,6 +19,7 @@ class TranslatedFile
   end
 
   def update_commit_hash(new_commit)
+    return if new_commit == front_matter[:commit]
     updated_content = content.sub(/(commit:\s*")[^"]+(")/, "\\1#{new_commit}\\2")
     path.write(updated_content)
   end

--- a/tasks/translation_pr.rb
+++ b/tasks/translation_pr.rb
@@ -147,7 +147,7 @@ DESCRIPTION
        "create",
        "--title", title,
        "--body", description,
-       "--base", "auto-translations-update",
+       "--base", "main",
        "--head", branch,
        "--repo", repo)
   end

--- a/tasks/translation_pr.rb
+++ b/tasks/translation_pr.rb
@@ -24,6 +24,7 @@ class TranslationPr
                   generate_description(diff_content),
                   source_latest_commit)
       end
+      sh("git", "switch", "main")
     end
   end
 

--- a/tasks/translation_pr.rb
+++ b/tasks/translation_pr.rb
@@ -91,15 +91,20 @@ DESCRIPTION
 
   def find_existed_pr
     pr_raw_info = Tempfile.open("pr.json") do |pr|
-      sh("gh",
-         "pr",
-         "view",
-         branch,
-         "--json", "closed,title,body",
-         "--repo", repo,
-         {out: pr}
-      )
-      pr.open.read
+      begin
+        sh("gh",
+          "pr",
+          "view",
+          branch,
+          "--json", "closed,title,body",
+          "--repo", repo,
+          {out: pr}
+        )
+        pr.open.read
+      rescue RuntimeError
+        # When existed pr doesn't exist, gh command raises RuntimeError.
+        ""
+      end
     end
     if pr_raw_info.empty?
       [nil, nil]

--- a/tasks/translation_pr.rb
+++ b/tasks/translation_pr.rb
@@ -118,7 +118,8 @@ DESCRIPTION
   end
 
   def commit_latest_hash(source_latest_commit)
-    translated_file.update_commit_hash(source_latest_commit)
+    return unless translated_file.update_commit_hash(source_latest_commit)
+
     sh("git", "add", translated_file.path.to_s)
     sh("git",
        "commit",

--- a/tasks/translation_pr.rb
+++ b/tasks/translation_pr.rb
@@ -35,7 +35,7 @@ class TranslationPr
   DIFF_END = "<!-- Please write your description under here. -->"
 
   def repo
-    "#{onwer}/#{repository}"
+    "#{owner}/#{repository}"
   end
 
   def owner

--- a/turbo/handbook/frames.md
+++ b/turbo/handbook/frames.md
@@ -2,7 +2,7 @@
 title: "Turboフレームを分解する"
 description: "Turbo Framesはページを独立したコンテキストに分解し、それらを遅延ロードできるようにし、インタラクションの範囲を制限します。"
 order: 4
-commit: "0b2c287"
+commit: "8849e6b"
 ---
 
 # Turboフレームを分解する


### PR DESCRIPTION
## Diff (Please don't change this section. It will be automatically updated.)

~~~diff
diff --git a/_source/handbook/04_frames.md b/_source/handbook/04_frames.md
index 6436375..e3c0d7a 100644
--- a/_source/handbook/04_frames.md
+++ b/_source/handbook/04_frames.md
@@ -113,7 +113,7 @@ After navigation finishes, a Frame will set the `[complete]` attribute on the
 
 ## Lazy-Loading Frames
 
-Frames that aren't visible when the page is first loaded can be marked with `loading="lazy"` such that they don't start loading until they become visible. This works exactly like the `lazy=true` attribute on `img`. It's a great way to delay loading of frames that sit inside `summary`/`detail` pairs or modals or anything else that starts out hidden and is then revealed.
+Frames that aren't visible when the page is first loaded can be marked with `loading="lazy"` such that they don't start loading until they become visible. This works exactly like the `loading="lazy"` attribute on `img`. It's a great way to delay loading of frames that sit inside `summary`/`detail` pairs or modals or anything else that starts out hidden and is then revealed.
 
 
 ## Cache Benefits to Loading Frames

~~~

<!-- Please write your description under here. -->

